### PR TITLE
Use optional values

### DIFF
--- a/render/v0/api_service.proto
+++ b/render/v0/api_service.proto
@@ -4,9 +4,10 @@ package render;
 
 option go_package = "github.com/limpidchart/lc-proto/render/v0;render";
 
-import "google/protobuf/timestamp.proto";
 import "chart.proto";
 import "view.proto";
+
+import "google/protobuf/timestamp.proto";
 
 // ChartStatus contains available chart statuses.
 enum ChartStatus {

--- a/render/v0/chart.proto
+++ b/render/v0/chart.proto
@@ -6,28 +6,30 @@ option go_package = "github.com/limpidchart/lc-proto/render/v0;render";
 
 import "scale.proto";
 
+import "google/protobuf/wrappers.proto";
+
 // ChartSizes represents options to configure chart sizes.
 message ChartSizes {
   // Chart width.
-  int32 width = 1;
+  google.protobuf.Int32Value width = 1;
 
   // Chart height.
-  int32 height = 2;
+  google.protobuf.Int32Value height = 2;
 }
 
 // ChartMargins represents options to configure chart margins.
 message ChartMargins {
   // Top margin.
-  int32 margin_top = 1;
+  google.protobuf.Int32Value margin_top = 1;
 
   // Bottom margin.
-  int32 margin_bottom = 2;
+  google.protobuf.Int32Value margin_bottom = 2;
 
   // Left margin.
-  int32 margin_left = 3;
+  google.protobuf.Int32Value margin_left = 3;
 
   // Right margin.
-  int32 margin_right = 4;
+  google.protobuf.Int32Value margin_right = 4;
 }
 
 // ChartAxes represents options to configure chart axes.

--- a/render/v0/scale.proto
+++ b/render/v0/scale.proto
@@ -4,6 +4,8 @@ package render;
 
 option go_package = "github.com/limpidchart/lc-proto/render/v0;render";
 
+import "google/protobuf/wrappers.proto";
+
 // ChartScale represents options to configure chart scale.
 message ChartScale {
   // ChartScaleKind contains available scale kinds.
@@ -17,10 +19,10 @@ message ChartScale {
   ChartScaleKind kind = 1;
 
   // Start of the scale range.
-  int32 range_start = 2;
+  google.protobuf.Int32Value range_start = 2;
 
   // End of the scale range.
-  int32 range_end = 3;
+  google.protobuf.Int32Value range_end = 3;
 
   // Start of the numeric scale domain.
   float domain_num_start = 4;
@@ -36,8 +38,8 @@ message ChartScale {
   bool no_boundaries_offset = 7;
 
   // Inner padding for categories.
-  float inner_padding = 8;
+  google.protobuf.FloatValue inner_padding = 8;
 
   // Outer padding for categories.
-  float outer_padding = 9;
+  google.protobuf.FloatValue outer_padding = 9;
 }

--- a/render/v0/view.proto
+++ b/render/v0/view.proto
@@ -8,6 +8,8 @@ import "color.proto";
 import "scale.proto";
 import "view_values.proto";
 
+import "google/protobuf/wrappers.proto";
+
 // ChartView represents options to configure chart view.
 message ChartView {
   // ChartViewKind contains available view kinds.
@@ -71,19 +73,19 @@ message ChartView {
   ChartViewColors colors = 7;
 
   // Set bar visibility for bar view.
-  bool bar_label_visible = 8;
+  google.protobuf.BoolValue bar_label_visible = 8;
 
   // One of the available bar label positions for bar view.
   ChartViewBarLabelPosition bar_label_position = 9;
 
   // Set bar visibility for view with points.
-  bool point_visible = 10;
+  google.protobuf.BoolValue point_visible = 10;
 
   // One of the available point types for view with points.
   ChartViewPointType point_type = 11;
 
   // Set point visibility for view with points.
-  bool point_label_visible = 12;
+  google.protobuf.BoolValue point_label_visible = 12;
 
   // One of the available point label positions for view with points.
   ChartViewPointLabelPosition point_label_position = 13;


### PR DESCRIPTION
Add `google/protobuf/wrappers.proto` to use optional values in
`ChartAPI` and `ChartRenderer` services.