### PR TITLE
Shorten colors fields names and update bars colors

### DIFF
--- a/render/v0/view.proto
+++ b/render/v0/view.proto
@@ -87,14 +87,14 @@ message ChartView {
 // ChartViewColors represents options to configure view colors.
 message ChartViewColors {
   // View fill color.
-  ChartElementColor fill_color = 1;
+  ChartElementColor fill = 1;
 
   // View stroke color.
-  ChartElementColor stroke_color = 2;
+  ChartElementColor stroke = 2;
 
   // View point fill color.
-  ChartElementColor point_fill_color = 3;
+  ChartElementColor point_fill = 3;
 
   // View point stroke color.
-  ChartElementColor point_stroke_color = 4;
+  ChartElementColor point_stroke = 4;
 }

--- a/render/v0/view_values.proto
+++ b/render/v0/view_values.proto
@@ -6,13 +6,18 @@ option go_package = "github.com/limpidchart/lc-proto/render/v0;render";
 
 import "color.proto";
 
-// ChartViewBarsValues represents options for bar values.
+// ChartViewBarsValues represents options for bars values.
 message ChartViewBarsValues {
+  // ChartViewBarsColors represents options to configure bars values colors.
+  message ChartViewBarsColors {
+    ChartElementColor fill = 1;
+    ChartElementColor stroke = 2;
+  }
+
   // BarsDataset represents a single dataset with several bars.
   message BarsDataset {
     repeated float values = 1;
-    ChartElementColor fill_color = 2;
-    ChartElementColor stroke_color = 3;
+    ChartViewBarsColors colors = 2;
   }
 
   // Array of configured bars datasets.


### PR DESCRIPTION
Remove "*Color" suffix from colors fields names.

Move bars values colors under separate struct.